### PR TITLE
Added option to exclude specific selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,15 @@ This meant I had to make my own selectors have a lot more specificity in order f
 
 # Options
 
- - `repeat`: number - The number of times we prepend `options.stackableRoot` in front of your selector
+ - `repeat`: number -- The number of times we prepend `options.stackableRoot` in front of your selector
  	 - Default: `3`
- - `overrideIds`: bool - Whether we should add `!important` to all declarations that use id's in any way. Because id's are so specific, the only way(essentially) to overcome another id is to use `!important`.
+ - `overrideIds`: bool -- Whether we should add `!important` to all declarations that use id's in any way. Because id's are so specific, the only way(essentially) to overcome another id is to use `!important`.
  	 - Default: `true`
- - `stackableRoot`: string - Selector that is repeated to make up the piece that is added to increase specificity
+ - `stackableRoot`: string -- Selector that is repeated to make up the piece that is added to increase specificity
  	 - Default: `:root`
  	 - *Warning:* The default `:root` pseudo-class selector is not supported in IE8-. To support IE-, you can change this option to a class such as `.my-root` and add it to the `<html class="my-root">` tag in your markup.
+ - `ignore`: `Array|String` -- Selectors that should be excluded from incresing specificity. Accepts any glob expression supported by [minimatch](https://github.com/isaacs/minimatch).
+	 - Default: `[]`
 
 
 # Tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-increase-specificity",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "PostCSS plugin to increase the specificity of your selectors",
   "keywords": [
     "postcss",
@@ -19,6 +19,7 @@
     "test": "mocha"
   },
   "dependencies": {
+    "minimatch": "^3.0.3",
     "object-assign": "^3.0.0",
     "postcss": "^5.1.2",
     "string.prototype.repeat": "^0.2.0"

--- a/test/fixtures/ignore.css
+++ b/test/fixtures/ignore.css
@@ -9,3 +9,7 @@
 .anotherClass ul li a:hover {
 	color: #f00;
 }
+
+.foo {
+	background: #f00;
+}

--- a/test/fixtures/ignore.css
+++ b/test/fixtures/ignore.css
@@ -1,0 +1,11 @@
+.ignoreClass {
+	background: #f00;
+}
+
+.ignoreClass2 {
+	background: #f00;
+}
+
+.anotherClass ul li a:hover {
+	color: #f00;
+}

--- a/test/fixtures/ignore.expected.css
+++ b/test/fixtures/ignore.expected.css
@@ -1,0 +1,11 @@
+.ignoreClass {
+	background: #f00;
+}
+
+.ignoreClass2 {
+	background: #f00;
+}
+
+.anotherClass ul li a:hover {
+	color: #f00;
+}

--- a/test/fixtures/ignore.expected.css
+++ b/test/fixtures/ignore.expected.css
@@ -9,3 +9,7 @@
 .anotherClass ul li a:hover {
 	color: #f00;
 }
+
+:root:root:root .foo {
+	background: #f00;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -115,6 +115,16 @@ describe('postcss-increase-specificity', function() {
 			}
 		);
 	});
+
+	it('should ignore classes that listed in a `options.ignore`', function() {
+		return testPlugin(
+			'./test/fixtures/ignore.css',
+			'./test/fixtures/ignore.expected.css',
+			{
+				ignore: ['.ignoreCl*', '.another*']
+			}
+		);
+	});
 });
 
 


### PR DESCRIPTION
`ignore: ['.sampleclass']` -- will exclude classes from increasing specificity.
### Example

``` js
var postcss = require('postcss');
var increaseSpecificity = require('postcss-increase-specificity');

var fs = require('fs');

var mycss = fs.readFileSync('input.css', 'utf8');

// Process your CSS with postcss-increase-specificity
var output = postcss([
        increaseSpecificity({
             ignore: ['.ignoreCl*', '.another*']
        })
    ])
    .process(mycss)
    .css;

console.log(output);
```

**Source**

``` css
.ignoreClass {
    background: #f00;
}

.ignoreClass2 {
    background: #f00;
}

.anotherClass ul li a:hover {
    color: #f00;
}

.foo {
    background: #f00;
}
```

**Output**

``` css
.ignoreClass {
    background: #f00;
}

.ignoreClass2 {
    background: #f00;
}

.anotherClass ul li a:hover {
    color: #f00;
}

:root:root:root .foo {
    background: #f00;
}
```
