### PR TITLE
Use `:not(#\20)` stackable root - more specificity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 
 
+# Upcoming release
+
+ - switch from `:root` to `:not(#\20)` to get more specificity in selectors
+   - Thanks to [@subzey][] for the [idea][] and [@iamstarkov][] for the contribution [#9][]
+
+[idea]: https://twitter.com/subzey/status/829050478721896448
+[@subzey]: https://github.com/subzey
+[@iamstarkov]: https://github.com/iamstarkov
+[#9]: https://github.com/MadLittleMods/postcss-increase-specificity/pull/9
+
 # v0.3.0 - 2016-9-9
 
  - Update to postcss@5.x

--- a/index.js
+++ b/index.js
@@ -4,15 +4,18 @@ var postcss = require('postcss');
 var objectAssign = require('object-assign');
 require('string.prototype.repeat');
 
-// Plugin that adds `:root` selectors to the front of the rule thus increasing specificity
+// Plugin that adds `:not(#\\20)` selectors to the front of the rule thus increasing specificity
 module.exports = postcss.plugin('postcss-increase-specifity', function(options) {
 	var defaults = {
-		// The number of times `:root` is appended in front of the selector
+		// The number of times `:not(#\\20)` is appended in front of the selector
 		repeat: 3,
 		// Whether to add !important to declarations in rules with id selectors
 		overrideIds: true,
 		// The thing we repeat over and over to make up the piece that increases specificity
-		stackableRoot: ':root'
+		// > Consider use :not(#\20), :not(.\20) and :not(\20)
+		// > Rationale: \20 is a css escape for U+0020 Space, and neither classname, nor id, nor tagname can contain a space
+		// > — https://twitter.com/subzey/status/829050478721896448
+		stackableRoot: ':not(#\\20)'
 	};
 
 	var opts = objectAssign({}, defaults, options);
@@ -21,10 +24,10 @@ module.exports = postcss.plugin('postcss-increase-specifity', function(options) 
 		css.walkRules(function(rule) {
 			rule.selectors = rule.selectors.map(function(selector) {
 				// Apply it to the selector itself if the selector is a `root` level component
-				// `html:root:root:root`
+				// `html:not(#\\20):not(#\\20):not(#\\20)`
 				if(
 					selector === 'html' ||
-					selector === ':root' ||
+					selector === ':not(#\\20)' ||
 					selector === ':host' ||
 					selector === opts.stackableRoot
 				) {
@@ -32,14 +35,14 @@ module.exports = postcss.plugin('postcss-increase-specifity', function(options) 
 				}
 
 				// Otherwise just make it a descendant (this is what will happen most of the time)
-				// `:root:root:root .foo`
+				// `:not(#\\20):not(#\\20):not(#\\20) .foo`
 				return opts.stackableRoot.repeat(opts.repeat) + ' ' + selector;
 			});
 
 			if(opts.overrideIds) {
 				if(
 					// If an id is in there somewhere
-					(/#/).test(rule.selector) ||
+					(/#(?!\\)/).test(rule.selector) ||
 					// Or it is an attribute selector with an id
 					(/\[id/).test(rule.selector)
 				) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "tdd": "mocha --watch"
   },
   "dependencies": {
     "object-assign": "^3.0.0",

--- a/test/fixtures/attribute-id.expected.css
+++ b/test/fixtures/attribute-id.expected.css
@@ -1,7 +1,7 @@
-:root:root:root [id="foo"] {
+:not(#\20):not(#\20):not(#\20) [id="foo"] {
 	background: #f00 !important;
-}	
+}
 
-:root:root:root [id^="bar"] {
+:not(#\20):not(#\20):not(#\20) [id^="bar"] {
 	background: #0f0 !important;
-}	
+}

--- a/test/fixtures/classes.expected.css
+++ b/test/fixtures/classes.expected.css
@@ -1,3 +1,3 @@
-:root:root:root .foo {
+:not(#\20):not(#\20):not(#\20) .foo {
 	background: #f00;
 }

--- a/test/fixtures/ids-no-override-option.expected.css
+++ b/test/fixtures/ids-no-override-option.expected.css
@@ -1,3 +1,3 @@
-:root:root:root #foo {
+:not(#\20):not(#\20):not(#\20) #foo {
 	background: #f00;
 }

--- a/test/fixtures/ids.expected.css
+++ b/test/fixtures/ids.expected.css
@@ -1,3 +1,3 @@
-:root:root:root #foo {
+:not(#\20):not(#\20):not(#\20) #foo {
 	background: #f00 !important;
 }

--- a/test/fixtures/multiple-classes.expected.css
+++ b/test/fixtures/multiple-classes.expected.css
@@ -1,3 +1,3 @@
-:root:root:root .foo, :root:root:root .bar {
+:not(#\20):not(#\20):not(#\20) .foo, :not(#\20):not(#\20):not(#\20) .bar {
 	background: #f00;
 }

--- a/test/fixtures/no-mangle-important-decl-in-id.expected.css
+++ b/test/fixtures/no-mangle-important-decl-in-id.expected.css
@@ -1,3 +1,3 @@
-:root:root:root #foo {
+:not(#\20):not(#\20):not(#\20) #foo {
 	background: #f00 !important;
 }

--- a/test/fixtures/repeat-option.expected.css
+++ b/test/fixtures/repeat-option.expected.css
@@ -1,7 +1,7 @@
-html:root:root:root:root:root {
+html:not(#\20):not(#\20):not(#\20):not(#\20):not(#\20) {
 	background: #fff;
 }
 
-:root:root:root:root:root .foo {
+:not(#\20):not(#\20):not(#\20):not(#\20):not(#\20) .foo {
 	background: #f00;
 }

--- a/test/fixtures/root-level-selectors.css
+++ b/test/fixtures/root-level-selectors.css
@@ -2,7 +2,7 @@ html {
 	background: #f00;
 }
 
-:root {
+:not(#\20) {
 	background: #0f0;
 }
 

--- a/test/fixtures/root-level-selectors.expected.css
+++ b/test/fixtures/root-level-selectors.expected.css
@@ -1,11 +1,11 @@
-html:root:root:root {
+html:not(#\20):not(#\20):not(#\20) {
 	background: #f00;
 }
 
-:root:root:root:root {
+:not(#\20):not(#\20):not(#\20):not(#\20) {
 	background: #0f0;
 }
 
-:host:root:root:root {
+:host:not(#\20):not(#\20):not(#\20) {
 	background: #0f0;
 }

--- a/test/fixtures/selection-pseudo.expected.css
+++ b/test/fixtures/selection-pseudo.expected.css
@@ -1,6 +1,6 @@
-:root:root:root ::selection {
+:not(#\20):not(#\20):not(#\20) ::selection {
 	background-color: #fcf1ab; color: #000;
 }
-:root:root:root ::-moz-selection {
+:not(#\20):not(#\20):not(#\20) ::-moz-selection {
 	background-color: #fcf1ab; color: #000;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -64,7 +64,7 @@ describe('postcss-increase-specificity', function() {
 		return testPlugin('./test/fixtures/attribute-id.css', './test/fixtures/attribute-id.expected.css');
 	});
 
-	it('should work with root level selectors `html, :root, :host`', function() {
+	it('should work with root level selectors `html, :not(#\\20), :host`', function() {
 		return testPlugin('./test/fixtures/root-level-selectors.css', './test/fixtures/root-level-selectors.expected.css');
 	});
 
@@ -76,7 +76,7 @@ describe('postcss-increase-specificity', function() {
 		return testPlugin('./test/fixtures/no-mangle-important-decl-in-id.css', './test/fixtures/no-mangle-important-decl-in-id.expected.css');
 	});
 
-	it('should repeat `:root` appropriately `options.repeat', function() {
+	it('should repeat `:not(#\\20)` appropriately `options.repeat', function() {
 		return testPlugin(
 			'./test/fixtures/repeat-option.css',
 			'./test/fixtures/repeat-option.expected.css',
@@ -116,6 +116,3 @@ describe('postcss-increase-specificity', function() {
 		);
 	});
 });
-
-
-


### PR DESCRIPTION
Fix https://github.com/MadLittleMods/postcss-increase-specificity/issues/8

Here I am with a PR 😄 

Use `:not(#\20)` stackable root to get more specificity.