### PR TITLE
Added regular expression to match keywords inside @keyframe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 npm-debug.log
-
+.history/
+.vscode/
 todo.md

--- a/index.js
+++ b/index.js
@@ -22,14 +22,13 @@ module.exports = postcss.plugin('postcss-increase-specificity', function(options
 
 	return function(css) {
 		css.walkRules(function(rule) {
-			rule.selectors = rule.selectors.map(function(selector) {
-				// Avoid adding additional selectors (stackableRoot) to descendants of @keyframe {}
-				// i.e. `from`, `to`, or `{number}%`
-				var regex = /^from$|^to$|^[0-9]+%/;
-				if (regex.test(selector)) {
-					return selector;
-				}
+			// Avoid adding additional selectors (stackableRoot) to descendants of @keyframe {}
+			// i.e. `from`, `to`, or `{number}%`
+			if (rule.parent.type === 'atrule' && rule.parent.name.indexOf('keyframe') > -1) {
+				return true;
+			}
 
+			rule.selectors = rule.selectors.map(function(selector) {
 				// Apply it to the selector itself if the selector is a `root` level component
 				// `html:not(#\\9):not(#\\9):not(#\\9)`
 				if(

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = postcss.plugin('postcss-increase-specificity', function(options
 			rule.selectors = rule.selectors.map(function(selector) {
 				// Avoid adding additional selectors (stackableRoot) to descendants of @keyframe {}
 				// i.e. `from`, `to`, or `{number}%`
-				var regex = /^from$|^to$|[0-9]*[,]?\s?[0-9]+%/;
+				var regex = /^from$|^to$|^[0-9]+%/;
 				if (regex.test(selector)) {
 					return selector;
 				}

--- a/index.js
+++ b/index.js
@@ -23,6 +23,13 @@ module.exports = postcss.plugin('postcss-increase-specificity', function(options
 	return function(css) {
 		css.walkRules(function(rule) {
 			rule.selectors = rule.selectors.map(function(selector) {
+				// Avoid adding additional selectors (stackableRoot) to descendants of @keyframe {}
+				// i.e. `from`, `to`, or `{number}%`
+				var regex = /^from$|^to$|[0-9]*[,]?\s?[0-9]+%/;
+				if (regex.test(selector)) {
+					return selector;
+				}
+
 				// Apply it to the selector itself if the selector is a `root` level component
 				// `html:not(#\\9):not(#\\9):not(#\\9)`
 				if(

--- a/test/fixtures/keyframe.css
+++ b/test/fixtures/keyframe.css
@@ -1,4 +1,4 @@
-@keyframes custom-amination {
+@keyframes custom-animation {
   from { opacity: 0; }
   50% { opacity: 0.5; }
   60%, 70% {opacity: 0.7; }

--- a/test/fixtures/keyframe.css
+++ b/test/fixtures/keyframe.css
@@ -1,0 +1,6 @@
+@keyframes custom-amination {
+  from { opacity: 0; }
+  50% { opacity: 0.5; }
+  60%, 70% {opacity: 0.7; }
+  to { opacity: 1; }
+}

--- a/test/fixtures/keyframe.expected.css
+++ b/test/fixtures/keyframe.expected.css
@@ -1,4 +1,4 @@
-@keyframes custom-amination {
+@keyframes custom-animation {
   from { opacity: 0; }
   50% { opacity: 0.5; }
   60%, 70% {opacity: 0.7; }

--- a/test/fixtures/keyframe.expected.css
+++ b/test/fixtures/keyframe.expected.css
@@ -1,0 +1,6 @@
+@keyframes custom-amination {
+  from { opacity: 0; }
+  50% { opacity: 0.5; }
+  60%, 70% {opacity: 0.7; }
+  to { opacity: 1; }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -115,4 +115,8 @@ describe('postcss-increase-specificity', function() {
 			}
 		);
 	});
+
+	it('should not change descendant of @keyframes', function() {
+		return testPlugin('./test/fixtures/keyframe.css', './test/fixtures/keyframe.expected.css');
+	});
 });


### PR DESCRIPTION
By default the plugin adds additional selectors (stackableRoot) to @keyframe descendants, i.e. `from`, `to`, `{number}%` that break custom animations.

Added regular expression to match aforementioned keywords inside @keyframe block and ignore them;

Closes #7 