### PR TITLE
Add functionality to disable plugin via comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,23 @@ html:not(#\9):not(#\9):not(#\9) {
 
 ## Only apply to certain sections of styles
 
-[`postcss-plugin-context`](https://github.com/postcss/postcss-plugin-context) allows you to apply plugins to only in certain areas of of your CSS.
+There are two ways handle this. If the majority of your CSS needs to increase specificity, then you can leverage inline comments to disable/enable blocks of rules.
+
+To temporarily disable `postcss-increase-specificity`, use block comments in the following format:
+
+```css
+/* postcss-increase-specificity disable */
+.foo {
+  content: 'cant touch this';
+}
+/* postcss-increase-specificity enable */
+
+.bar {
+  content: 'but i can!';
+}
+```
+
+Otherwise, [`postcss-plugin-context`](https://github.com/postcss/postcss-plugin-context) allows you to apply plugins to only in certain areas of of your CSS using `@context`.
 
 
 ```js

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function checkForEnableDisableComments(node) {
 	if (!node) return null;
 
 	for (var prev = node; prev = prev.prev(); ) {
-		if (prev.type !== 'comment') return null;
+		if (prev.type !== 'comment' && prev.type !== 'decl') return null;
 		if (DISABLE_PLUGIN_RE.test(prev.text)) {
 			return true;
 		} else if (ENABLE_PLUGIN_RE.test(prev.text)) {

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ require('string.prototype.repeat');
 
 var CSS_ESCAPED_TAB = '\\9';
 
-var BLOCK_DISABLE = /postcss-increase-specificity disable/;
-var BLOCK_ENABLE = /postcss-increase-specificity enable/;
+var DISABLE_PLUGIN_RE = /postcss-increase-specificity disable/;
+var ENABLE_PLUGIN_RE = /postcss-increase-specificity enable/;
 
 function increaseSpecifityOfRule(rule, opts) {
 	rule.selectors = rule.selectors.map(function(selector) {

--- a/test/fixtures/disabled-block-extra-comments.css
+++ b/test/fixtures/disabled-block-extra-comments.css
@@ -6,5 +6,5 @@
 /* postcss-increase-specificity enable */
 
 .bar {
-  color: #ef0;
+	color: #ef0;
 }

--- a/test/fixtures/disabled-block-extra-comments.css
+++ b/test/fixtures/disabled-block-extra-comments.css
@@ -1,0 +1,10 @@
+/* postcss-increase-specificity disable */
+/* Some other comment you picked up instead of the one above */
+.foo {
+	background: #f00;
+}
+/* postcss-increase-specificity enable */
+
+.bar {
+  color: #ef0;
+}

--- a/test/fixtures/disabled-block-extra-comments.expected.css
+++ b/test/fixtures/disabled-block-extra-comments.expected.css
@@ -1,0 +1,10 @@
+/* postcss-increase-specificity disable */
+/* Some other comment you picked up instead of the one above */
+.foo {
+	background: #f00;
+}
+/* postcss-increase-specificity enable */
+
+:not(#\9):not(#\9):not(#\9) .bar {
+	color: #ef0;
+}

--- a/test/fixtures/disabled-block-extra-declaration.css
+++ b/test/fixtures/disabled-block-extra-declaration.css
@@ -1,0 +1,12 @@
+/* postcss-increase-specificity disable */
+
+my-decl: 'wo';
+
+.foo {
+	background: #f00;
+}
+/* postcss-increase-specificity enable */
+
+.bar {
+	color: #ef0;
+}

--- a/test/fixtures/disabled-block-extra-declaration.expected.css
+++ b/test/fixtures/disabled-block-extra-declaration.expected.css
@@ -1,0 +1,12 @@
+/* postcss-increase-specificity disable */
+
+my-decl: 'wo';
+
+.foo {
+	background: #f00;
+}
+/* postcss-increase-specificity enable */
+
+:not(#\9):not(#\9):not(#\9) .bar {
+	color: #ef0;
+}

--- a/test/fixtures/disabled-block.css
+++ b/test/fixtures/disabled-block.css
@@ -5,5 +5,5 @@
 /* postcss-increase-specificity enable */
 
 .bar {
-  color: #ef0;
+	color: #ef0;
 }

--- a/test/fixtures/disabled-block.css
+++ b/test/fixtures/disabled-block.css
@@ -1,0 +1,9 @@
+/* postcss-increase-specificity disable */
+.foo {
+	background: #f00;
+}
+/* postcss-increase-specificity enable */
+
+.bar {
+  color: #ef0;
+}

--- a/test/fixtures/disabled-block.expected.css
+++ b/test/fixtures/disabled-block.expected.css
@@ -1,0 +1,9 @@
+/* postcss-increase-specificity disable */
+.foo {
+	background: #f00;
+}
+/* postcss-increase-specificity enable */
+
+:not(#\9):not(#\9):not(#\9) .bar {
+	color: #ef0;
+}

--- a/test/fixtures/disabled-stylesheet.css
+++ b/test/fixtures/disabled-stylesheet.css
@@ -1,0 +1,13 @@
+/* postcss-increase-specificity disable */
+.foo {
+	background: #f00;
+}
+
+.bar {
+  color: #ef0;
+}
+
+/* some other random comment that should not enable */
+.baz {
+  color: #040;
+}

--- a/test/fixtures/disabled-stylesheet.css
+++ b/test/fixtures/disabled-stylesheet.css
@@ -4,10 +4,10 @@
 }
 
 .bar {
-  color: #ef0;
+	color: #ef0;
 }
 
 /* some other random comment that should not enable */
 .baz {
-  color: #040;
+	color: #040;
 }

--- a/test/fixtures/disabled-stylesheet.expected.css
+++ b/test/fixtures/disabled-stylesheet.expected.css
@@ -1,0 +1,13 @@
+/* postcss-increase-specificity disable */
+.foo {
+	background: #f00;
+}
+
+.bar {
+  color: #ef0;
+}
+
+/* some other random comment that should not enable */
+.baz {
+  color: #040;
+}

--- a/test/fixtures/disabled-stylesheet.expected.css
+++ b/test/fixtures/disabled-stylesheet.expected.css
@@ -4,10 +4,10 @@
 }
 
 .bar {
-  color: #ef0;
+	color: #ef0;
 }
 
 /* some other random comment that should not enable */
 .baz {
-  color: #040;
+	color: #040;
 }

--- a/test/fixtures/multiple-disabled-blocks.css
+++ b/test/fixtures/multiple-disabled-blocks.css
@@ -1,0 +1,15 @@
+/* postcss-increase-specificity disable */
+.noop {
+	background: #f00;
+}
+/* postcss-increase-specificity enable */
+
+.bar {
+  color: #ef0;
+}
+
+/* postcss-increase-specificity disable */
+.noop2 {
+	background: #f00;
+}
+/* postcss-increase-specificity enable */

--- a/test/fixtures/multiple-disabled-blocks.css
+++ b/test/fixtures/multiple-disabled-blocks.css
@@ -5,7 +5,7 @@
 /* postcss-increase-specificity enable */
 
 .bar {
-  color: #ef0;
+	color: #ef0;
 }
 
 /* postcss-increase-specificity disable */

--- a/test/fixtures/multiple-disabled-blocks.expected.css
+++ b/test/fixtures/multiple-disabled-blocks.expected.css
@@ -1,0 +1,15 @@
+/* postcss-increase-specificity disable */
+.noop {
+	background: #f00;
+}
+/* postcss-increase-specificity enable */
+
+:not(#\9):not(#\9):not(#\9) .bar {
+	color: #ef0;
+}
+
+/* postcss-increase-specificity disable */
+.noop2 {
+	background: #f00;
+}
+/* postcss-increase-specificity enable */

--- a/test/fixtures/partially-disabled-stylesheet.css
+++ b/test/fixtures/partially-disabled-stylesheet.css
@@ -1,0 +1,12 @@
+.foo {
+	background: #f00;
+}
+
+/* postcss-increase-specificity disable */
+.bar {
+  color: #ef0;
+}
+
+.baz {
+  color: #040;
+}

--- a/test/fixtures/partially-disabled-stylesheet.css
+++ b/test/fixtures/partially-disabled-stylesheet.css
@@ -4,9 +4,9 @@
 
 /* postcss-increase-specificity disable */
 .bar {
-  color: #ef0;
+	color: #ef0;
 }
 
 .baz {
-  color: #040;
+	color: #040;
 }

--- a/test/fixtures/partially-disabled-stylesheet.expected.css
+++ b/test/fixtures/partially-disabled-stylesheet.expected.css
@@ -1,0 +1,12 @@
+:not(#\9):not(#\9):not(#\9) .foo {
+	background: #f00;
+}
+
+/* postcss-increase-specificity disable */
+.bar {
+  color: #ef0;
+}
+
+.baz {
+  color: #040;
+}

--- a/test/fixtures/partially-disabled-stylesheet.expected.css
+++ b/test/fixtures/partially-disabled-stylesheet.expected.css
@@ -4,9 +4,9 @@
 
 /* postcss-increase-specificity disable */
 .bar {
-  color: #ef0;
+	color: #ef0;
 }
 
 .baz {
-  color: #040;
+	color: #040;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -135,4 +135,8 @@ describe('postcss-increase-specificity', function() {
 	it('should support an entirely disabled stylesheet', function() {
 		return testPlugin('./test/fixtures/disabled-stylesheet.css', './test/fixtures/disabled-stylesheet.expected.css');
 	});
+
+	it('should support a partially disabled stylesheet', function() {
+		return testPlugin('./test/fixtures/partially-disabled-stylesheet.css', './test/fixtures/partially-disabled-stylesheet.expected.css');
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -139,4 +139,8 @@ describe('postcss-increase-specificity', function() {
 	it('should support a partially disabled stylesheet', function() {
 		return testPlugin('./test/fixtures/partially-disabled-stylesheet.css', './test/fixtures/partially-disabled-stylesheet.expected.css');
 	});
+
+	it('should support disabled blocks of rules with declarations in between', function() {
+		return testPlugin('./test/fixtures/disabled-block-extra-declaration.css', './test/fixtures/disabled-block-extra-declaration.expected.css');
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -127,4 +127,8 @@ describe('postcss-increase-specificity', function() {
 	it('should support disabled blocks of rules with comments in between', function() {
 		return testPlugin('./test/fixtures/disabled-block-extra-comments.css', './test/fixtures/disabled-block-extra-comments.expected.css');
 	});
+
+	it('should support multiple disabled blocks of rules', function() {
+		return testPlugin('./test/fixtures/multiple-disabled-blocks.css', './test/fixtures/multiple-disabled-blocks.expected.css');
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -131,4 +131,8 @@ describe('postcss-increase-specificity', function() {
 	it('should support multiple disabled blocks of rules', function() {
 		return testPlugin('./test/fixtures/multiple-disabled-blocks.css', './test/fixtures/multiple-disabled-blocks.expected.css');
 	});
+
+	it('should support an entirely disabled stylesheet', function() {
+		return testPlugin('./test/fixtures/disabled-stylesheet.css', './test/fixtures/disabled-stylesheet.expected.css');
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -123,4 +123,8 @@ describe('postcss-increase-specificity', function() {
 	it('should support disabled blocks of rules', function() {
 		return testPlugin('./test/fixtures/disabled-block.css', './test/fixtures/disabled-block.expected.css');
 	});
+
+	it('should support disabled blocks of rules with comments in between', function() {
+		return testPlugin('./test/fixtures/disabled-block-extra-comments.css', './test/fixtures/disabled-block-extra-comments.expected.css');
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -119,4 +119,8 @@ describe('postcss-increase-specificity', function() {
 	it('should not change the descendant rules of @keyframes', function() {
 		return testPlugin('./test/fixtures/keyframes.css', './test/fixtures/keyframes.expected.css');
 	});
+
+	it('should support disabled blocks of rules', function() {
+		return testPlugin('./test/fixtures/disabled-block.css', './test/fixtures/disabled-block.expected.css');
+	});
 });


### PR DESCRIPTION
Closes #17 

It only makes sense to support disabling blocks as this plugin only looks at the rule-level (as opposed to line/declaration level).

```css
/* postcss-increase-specificity disable */
.foo {
  content: "can't touch this";
}
/* postcss-increase-specificity enable */
```

Thanks to @MadLittleMods for creating this plugin (it's already been a huge help in a project)!