### PR TITLE
feat: Add body to root level components

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function increaseSpecifityOfRule(rule, opts) {
 		// `html:not(#\\9):not(#\\9):not(#\\9)`
 		if(
 			selector === 'html' ||
+			selector === 'body' ||
 			selector === ':root' ||
 			selector === ':host' ||
 			selector === opts.stackableRoot

--- a/test/fixtures/root-level-selectors.css
+++ b/test/fixtures/root-level-selectors.css
@@ -2,6 +2,10 @@ html {
 	background: #f00;
 }
 
+body {
+	background: #f00;
+}
+
 :not(#\9) {
 	background: #0f0;
 }

--- a/test/fixtures/root-level-selectors.expected.css
+++ b/test/fixtures/root-level-selectors.expected.css
@@ -2,6 +2,10 @@ html:not(#\9):not(#\9):not(#\9) {
 	background: #f00;
 }
 
+body:not(#\9):not(#\9):not(#\9) {
+	background: #f00;
+}
+
 :not(#\9):not(#\9):not(#\9):not(#\9) {
 	background: #0f0;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -64,7 +64,7 @@ describe('postcss-increase-specificity', function() {
 		return testPlugin('./test/fixtures/attribute-id.css', './test/fixtures/attribute-id.expected.css');
 	});
 
-	it('should work with root level selectors `html, :not(#\\9), :host`', function() {
+	it('should work with root level selectors `html, body, :not(#\\9), :host`', function() {
 		return testPlugin('./test/fixtures/root-level-selectors.css', './test/fixtures/root-level-selectors.expected.css');
 	});
 


### PR DESCRIPTION
`body` should be a root level component the same way `html` is one.