### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,11 @@ function increaseSpecifityOfRule(rule, opts) {
 		) {
 			return selector + opts.stackableRoot.repeat(opts.repeat);
 		}
+		
+		// Avoid this selectors when we are exporting or using Sass modules
+		if(/^\:(:export|:local|:global|)/.test(selector)){
+			return selector;
+		}
 
 		// Otherwise just make it a descendant (this is what will happen most of the time)
 		// `:not(#\\9):not(#\\9):not(#\\9) .foo`


### PR DESCRIPTION
The following change will avoid prefixing those selectors when using Sass modules or exporting