### PR TITLE
Avoid prefixing :export for css modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,12 @@ function increaseSpecifityOfRule(rule, opts) {
 		) {
 			return selector + opts.stackableRoot.repeat(opts.repeat);
 		}
+		
+		// Avoid prefix for :exports since :export block defines the symbols 
+		// that are going to be exported to the consumer
+		if (selector.indexOf(":export") !== -1) {
+		    return selector;
+		}
 
 		// Otherwise just make it a descendant (this is what will happen most of the time)
 		// `:not(#\\9):not(#\\9):not(#\\9) .foo`

--- a/test/fixtures/scss/export-option.expected.scss
+++ b/test/fixtures/scss/export-option.expected.scss
@@ -1,0 +1,15 @@
+:not(#\9):not(#\9):not(#\9) [id="foo"] {
+    background: #f00 !important;
+}
+
+:not(#\9):not(#\9):not(#\9) [id^="bar"] {
+    background: #0f0 !important;
+}
+
+:not(#\9):not(#\9):not(#\9) .foo {
+    background: #f00;
+}
+
+:export {
+    listColor: red;
+}

--- a/test/fixtures/scss/export-option.scss
+++ b/test/fixtures/scss/export-option.scss
@@ -1,0 +1,15 @@
+[id="foo"] {
+    background: #f00;
+}
+
+[id^="bar"] {
+    background: #0f0;
+}
+
+.foo {
+    background: #f00;
+}
+
+:export {
+    listColor: red;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -119,4 +119,8 @@ describe('postcss-increase-specificity', function() {
 	it('should not change the descendant rules of @keyframes', function() {
 		return testPlugin('./test/fixtures/keyframes.css', './test/fixtures/keyframes.expected.css');
 	});
+
+	it('should ignore :export option used in scss files', function() {
+		return testPlugin('./test/fixtures/scss/export-option.scss', './test/fixtures/scss/export-option.expected.scss');
+	});
 });


### PR DESCRIPTION
Avoid prefix for `:export` since `:export` block defines the symbols that are going to be exported to the consumer. It can be thought of functionally equivalent to the module.export